### PR TITLE
feat: Initial research for Flipper Zero Wi-Fi Marauder integration (s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://github.com/4k4xs4pH1r3/realtek
 
 Install & Activate `wifite` Ninja mode as root
 ----------
+*Note: The following script attempts to install many dependencies. For best results with WPA3 and Wi-Fi 6/7, ensure you are using recent versions of the Aircrack-ng suite, HCXTools, and Hashcat. Building these from source may be required if your distribution's packages are outdated.*
 ```bash
 apt update -y && apt install dirmngr sqlcipher aptitude -y && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7638D0442B90D010 04EE7237B7D453EC EF0F382A1A7B6500 && apt-get update -y && apt-get upgrade -y && aptitude install hcxtools libsqlite3-dev zlib1g-dev libncurses5-dev libgdbm-dev libbz2-dev libssl-dev libdb-dev libssl-dev build-essential libssl-dev libblas-dev libatlas-base-dev libpq-dev libffi-dev zlib1g-dev libxml2-dev libxslt1-dev zlib1g-dev libpcap-dev libpcap-dev -y && pip install psycopg2-binary pysqlcipher3 psycopg2 testresources && pip install --upgrade wheel pip install scapy && aptitude install && pip list --outdated && pip install --upgrade wheel && pip install --upgrade setuptools && sudo apt-get update -y && sudo apt-get install python2-dev libssl-dev libpcap-dev python3-scapy -y && cd /usr/share/ && git clone https://github.com/JPaulMora/Pyrit.git --depth=1 && sed -i "s/COMPILE_AESNI/COMPILE_AESNIX/" Pyrit/cpyrit/_cpyrit_cpu.c && cd Pyrit && python2 setup.py clean && python2 setup.py build && sudo python2 setup.py install && cd .. && pip install psycopg2-binary && pip install psycopg2 && pip install virtualenvwrapper && aptitude install neofetch git make clang libpcap-dev reaver tshark wireshark aircrack-ng pixiewps libssl-dev libcurl4-openssl-dev libpcap0.8-dev libcurl4-doc libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev libssl-doc -y && cd /usr/share/ && git clone https://github.com/ZerBea/hcxtools.git && cd hcxtools && make && make install && cd /usr/share && git clone https://github.com/ZerBea/hcxdumptool.git  && cd hcxdumptool && make && make install && cd /usr/share && git clone https://github.com/joswr1ght/cowpatty.git && cd cowpatty && make && make install && cd /usr/share && git clone https://github.com/aanarchyy/bully.git && cd bully/src && make && make install && neofetch && cd /usr/share && neofetch && cd && pip --version && python --version && sudo ln -s $(which hcxpcapngtool) /usr/local/bin/hcxpcaptool
 ```
@@ -195,11 +196,40 @@ Cracking a pre-captured handshake using John The Ripper (via the `--crack` optio
 #
 #
 
+## Real-Time Hashcat Cracking
+
+Wifite can now attempt to crack captured PMKIDs and WPA/WPA2 handshakes in real-time using Hashcat running in the background. This is useful for getting quick results on potentially weak passwords while other Wifite operations (like scanning or attacking other targets) continue.
+
+**Enabling the Feature:**
+*   To enable this feature, use the `--hashcat-realtime` command-line argument.
+
+**Wordlist Configuration:**
+*   `--hashcat-realtime-wordlist-dir <directory>`: By default, Wifite will iterate through wordlists found in `/usr/share/wordlists/`. You can specify a different directory using this option.
+*   `--hashcat-realtime-wordlist-file <file>`: To use a single, specific wordlist for real-time attempts (which overrides the directory search), use this option. This is recommended for faster, targeted attacks against potentially common passwords.
+
+**Custom Hashcat Options:**
+*   `--hashcat-realtime-options "<options_string>"`: Pass custom command-line options directly to Hashcat. For example, to use a specific rule file: `--hashcat-realtime-options "-r /path/to/rules/best64.rule"`. Ensure the options are quoted if they contain spaces.
+
+**CPU/GPU Control:**
+*   `--hashcat-realtime-force-cpu`: Force Hashcat to use only CPU resources (adds `--force -D 1` or similar to Hashcat). This can be useful if GPU resources are needed for other tasks or if GPU cracking is unstable.
+*   `--hashcat-realtime-gpu-devices <device_ids>`: Specify which GPU devices Hashcat should use (e.g., `1,3` for `--opencl-device-types 2 --opencl-device-ids 1,3`). Consult Hashcat documentation for device selection.
+
+**How It Works:**
+*   When a PMKID is captured (via `hcxdumptool`) or a WPA handshake is obtained and converted to `.hccapx` format (via `hcxpcapngtool`), Wifite will initiate a Hashcat session if real-time cracking is enabled.
+*   Real-time cracking operates on one target's hash at a time. If a new hash (e.g., from a different target) is captured, Wifite may switch the real-time cracking session to the new target or queue it.
+*   If a password is cracked, other attacks against that specific target are typically stopped, and the password is saved to `cracked.txt` and `cracked.json`.
+*   Status messages from Hashcat (speed, progress) will be displayed periodically in the Wifite console.
+
+**Important Considerations:**
+*   **Resource Intensive:** This feature can significantly increase CPU and/or GPU usage. Monitor system performance, especially on resource-constrained devices.
+*   **Hashcat & Dependencies:** A working installation of Hashcat (and its drivers for GPU cracking, e.g., OpenCL runtimes) and `hcxtools` (for `.hccapx` conversion) is required.
+*   **Experimental:** While functional, consider this an advanced feature. Behavior, performance, and output parsing may vary based on your system, drivers, Hashcat version, and the specific options used.
+
 Supported Operating Systems
 ---------------------------
 Wifite is designed specifically for the latest version of [**Kali** Linux](https://www.kali.org/). [ParrotSec](https://www.parrotsec.org/). [Ubuntu](http://releases.ubuntu.com/disco/) is also supported.
 
-Other pen-testing distributions (such as BackBox or Ubuntu) have outdated versions of the tools used by Wifite. Do not expect support unless you are using the latest versions of the *Required Tools*, and also [patched wireless drivers that support injection]().
+Other pen-testing distributions (such as BackBox or Ubuntu) may have outdated versions of the tools used by Wifite. Do not expect full support unless you are using the latest versions of the *Required Tools*, and also [patched wireless drivers that support injection](). For best results, especially with newer standards like WPA3, OWE, Wi-Fi 6/7, ensure your core tools (`airodump-ng`, `hcxdumptool`, `hashcat`, etc.) are up-to-date, potentially by building from source.
 
 Components that use Wifite
 --------------
@@ -237,6 +267,9 @@ Second, only the latest versions of these programs are supported and Wifite need
 
 Brief Feature List
 ------------------
+* Identifies WPA3 and OWE networks.
+* Shows inferred Wi-Fi 6/7 (ax/be) capabilities.
+* Real-time background cracking of captured PMKIDs and WPA handshakes using Hashcat.
 * [PMKID hash capture](https://hashcat.net/forum/thread-7717.html) (enabled by-default, force with: `--pmkid`)
 * WPS Offline Brute-Force Attack aka "Pixie-Dust". (enabled by-default, force with: `--wps-only --pixie`)
 * WPS Online Brute-Force Attack aka "PIN attack". (enabled by-default, force with: `--wps-only --no-pixie`)
@@ -270,6 +303,12 @@ Comparing this repo to the "old wifite" @ https://github.com/derv82/wifite
 * More-actively developed.
 * Python 3 support.
 * Sweet new ASCII banner.
+
+### WPA3, OWE, and Wi-Fi 6/7 Support
+* Wifite can now identify WPA3-SAE and OWE (Enhanced Open) networks.
+* Displays inferred Wi-Fi standards (802.11ax/Wi-Fi 6, 802.11be/Wi-Fi 7) based on network capabilities shown by `airodump-ng`.
+* For WPA3-SAE targets, Wifite prioritizes PMKID attacks. Traditional 4-way handshake capture (ineffective against WPA3-SAE) is skipped, and the user is informed.
+* Ensuring up-to-date versions of core tools (Aircrack-ng suite, HCXTools, Hashcat) is recommended for optimal Wi-Fi 6/7 and WPA3 support.
 
 What's gone?
 ------------

--- a/tests/attack/test_AttackAll.py
+++ b/tests/attack/test_AttackAll.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import MagicMock, patch, ANY
+
+from wifite.attack.all import AttackAll
+from wifite.model.target import Target
+from wifite.config import Configuration
+from wifite.util.color import Color
+
+class TestAttackAll(unittest.TestCase):
+
+    def setUp(self):
+        Configuration.initialize(load_yaml=False)
+        # Prevent actual attacks or lengthy operations
+        Configuration.no_deauth = True
+        Configuration.wps_pixie = False 
+        Configuration.wps_pin = False
+        Configuration.use_pmkid_only = False # Allow WPA handshake attack to be queued
+        Configuration.wordlist = None # Prevent local cracking attempts
+        Configuration.hashcat_realtime = True # Enable for these tests
+        Configuration.temp_dir = '/tmp/wifite_test_temp_all'
+        if not os.path.exists(Configuration.temp_dir):
+            os.makedirs(Configuration.temp_dir)
+
+
+    def tearDown(self):
+        if os.path.exists(Configuration.temp_dir):
+            import shutil
+            shutil.rmtree(Configuration.temp_dir)
+
+    @patch('wifite.attack.all.AttackWPA') # Mock the AttackWPA class
+    @patch('wifite.attack.all.AttackPMKID') # Mock the AttackPMKID class
+    @patch('wifite.attack.all.AttackWEP') # Mock AttackWEP
+    @patch('wifite.attack.all.AttackWPS.can_attack_wps', return_value=False) # No WPS attacks for simplicity
+    def test_attack_single_skips_if_realtime_cracked(self, mock_can_wps, MockAttackWEP, MockAttackPMKID, MockAttackWPA):
+        ''' Test that attack_single skips other attacks if RealtimeCrackManager reports password.'''
+        
+        mock_target_fields = ['RT:CR:AC:KE:D0:00', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '300', 'WPA2', 'CCMP', 'PSK', '-40', '10', '0', '0.0.0.0', '10', 'CrackedNet', '']
+        target = Target(mock_target_fields)
+
+        mock_rt_manager = MagicMock()
+        # Simulate that update_status finds a password for this target
+        mock_rt_manager.update_status.return_value = (target.bssid, 'password123')
+        # get_cracked_password will also be checked by attack_multiple before even calling attack_single
+        mock_rt_manager.get_cracked_password.return_value = 'password123'
+
+
+        # Call attack_multiple, which will call attack_single internally
+        # We are interested if attack_single correctly uses the info from update_status
+        # Need to patch Color.pl as it's called when a target is skipped due to being pre-cracked.
+        with patch('wifite.util.color.Color.pl') as mock_color_pl:
+            AttackAll.attack_multiple([target], realtime_crack_manager=mock_rt_manager)
+        
+        # Assert that no actual attack class (PMKID, WPA) was instantiated or run
+        # because the real-time manager should have "cracked" it.
+        MockAttackPMKID.assert_not_called()
+        MockAttackWPA.assert_not_called()
+        
+        # Check for the message indicating it was skipped because already cracked
+        found_skip_message = False
+        for call_arg in mock_color_pl.call_args_list:
+            if "already cracked by real-time manager" in call_arg[0][0]:
+                found_skip_message = True
+                break
+        self.assertTrue(found_skip_message, "Should print message that target was already cracked by real-time manager.")
+
+
+    @patch('wifite.attack.wpa.AttackWPA.run', return_value=True) # Mock AttackWPA's run to succeed
+    @patch('wifite.attack.wpa.AttackWPA.__init__', return_value=None) # Mock init to avoid issues
+    @patch('wifite.attack.pmkid.AttackPMKID') # Mock PMKID to prevent its run
+    @patch('wifite.attack.all.AttackWPS.can_attack_wps', return_value=False)
+    def test_attack_single_stops_realtime_if_other_attack_succeeds(self, mock_can_wps, MockAttackPMKID, mock_wpa_init, mock_wpa_run):
+        '''Test that attack_single stops real-time cracking if a standard attack succeeds.'''
+        Configuration.use_pmkid_only = False # Ensure WPA attack is in queue
+
+        mock_target_fields = ['RT:ST:OP:ME:XX:00', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '6', '144', 'WPA2', 'CCMP', 'PSK', '-50', '10', '0', '0.0.0.0', '12', 'StopRealTime', '']
+        target = Target(mock_target_fields)
+
+        mock_rt_manager = MagicMock()
+        mock_rt_manager.update_status.return_value = None # Real-time does not find password initially
+        mock_rt_manager.get_cracked_password.return_value = None # Not pre-cracked
+        mock_rt_manager.is_actively_cracking.return_value = True # Simulate it's active for this BSSID
+
+        # For AttackWPA to be "successful", its crack_result needs to be set.
+        # We mock the run to return True, and need to mock the attack object itself.
+        mock_wpa_instance = MagicMock()
+        mock_wpa_instance.run = mock_wpa_run 
+        mock_wpa_instance.success = True # Simulate successful crack by AttackWPA
+        mock_wpa_instance.crack_result = MagicMock() # Needs a crack_result object with save()
+        mock_wpa_instance.crack_result.save = MagicMock()
+        
+        # When AttackWPA is instantiated, return our mock_wpa_instance
+        # Need to use a new variable for the class mock to avoid conflict with instance mock
+        with patch('wifite.attack.all.AttackWPA', return_value=mock_wpa_instance) as PatchedAttackWPA:
+             AttackAll.attack_single(target, 0, realtime_crack_manager=mock_rt_manager)
+
+        # Assert that AttackWPA was instantiated with the target and manager
+        PatchedAttackWPA.assert_called_once_with(target, mock_rt_manager)
+        
+        # Assert that run was called on the WPA attack instance
+        mock_wpa_instance.run.assert_called_once()
+        
+        # Assert that stop_current_crack_attempt was called on the manager
+        mock_rt_manager.stop_current_crack_attempt.assert_called_once_with(cleanup_hash_file=False)
+
+
+if __name__ == '__main__':
+    if not hasattr(Configuration, 'temp_dir'):
+        Configuration.initialize(load_yaml=False)
+        Configuration.temp_dir = '/tmp/wifite_test_temp_all_main'
+        if not os.path.exists(Configuration.temp_dir):
+            os.makedirs(Configuration.temp_dir)
+    unittest.main()

--- a/tests/attack/test_AttackPMKID.py
+++ b/tests/attack/test_AttackPMKID.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from wifite.attack.pmkid import AttackPMKID
+from wifite.model.target import Target # Assuming Target can be instantiated for testing
+from wifite.config import Configuration
+# from wifite.realtime_crack_manager import RealtimeCrackManager # Not strictly needed if mocking the instance
+
+class TestAttackPMKID(unittest.TestCase):
+
+    def setUp(self):
+        Configuration.initialize(load_yaml=False)
+        Configuration.hashcat_realtime = False # Default to off unless specified in test
+        Configuration.wordlist = None # Avoid actual cracking attempts by default
+        Configuration.ignore_old_handshakes = True # Focus on capture part for some tests
+        Configuration.pmkid_timeout = 10 # Short timeout for tests
+        Configuration.temp_dir = '/tmp/wifite_test_temp_pmkid'
+        if not os.path.exists(Configuration.temp_dir):
+            os.makedirs(Configuration.temp_dir)
+
+
+    def tearDown(self):
+        if os.path.exists(Configuration.temp_dir):
+            import shutil
+            shutil.rmtree(Configuration.temp_dir)
+
+    @patch('wifite.tools.hashcat.HcxDumpTool') # Mocks the entire class
+    @patch('wifite.tools.hashcat.HcxPcapTool') # Mocks the entire class
+    @patch('wifite.tools.hashcat.Hashcat.crack_pmkid') # Mock the actual cracking call
+    @patch('os.path.exists', return_value=True) # Assume files exist generally
+    def test_run_starts_realtime_crack_if_enabled(self, mock_path_exists, mock_crack_pmkid, MockHcxPcapTool, MockHcxDumpTool):
+        Configuration.hashcat_realtime = True
+        Configuration.wordlist = None # Don't proceed to local cracking for this test
+
+        # Mock target
+        mock_target_fields = ['PM:KI:DB:SS:ID:00', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '300', 'WPA2', 'CCMP', 'PSK', '-40', '10', '0', '0.0.0.0', '8', 'PMKIDNet', '']
+        target = Target(mock_target_fields)
+
+        # Mock HcxPcapTool instance and its get_pmkid_hash method
+        mock_pcaptool_instance = MockHcxPcapTool.return_value
+        # Simulate a captured PMKID hash string being returned and then saved to a file
+        test_pmkid_hash_string = "testpmkid*pmkidbssid*pmkidstation*pmkidessid"
+        mock_pcaptool_instance.get_pmkid_hash.return_value = test_pmkid_hash_string
+        
+        # Mock HcxDumpTool instance
+        mock_dumptool_instance = MockHcxDumpTool.return_value
+        # Allow poll to be called, make it indicate process is running then stopped
+        mock_dumptool_instance.poll.side_effect = [None, None, True] 
+
+        # Mock RealtimeCrackManager
+        mock_rt_manager = MagicMock()
+        mock_rt_manager.is_actively_cracking.return_value = False
+        mock_rt_manager.get_cracked_password.return_value = None
+
+        # Mock save_pmkid to return a predictable file path
+        expected_pmkid_filepath = os.path.join(Configuration.wpa_handshake_dir, 'pmkid_PMKIDNet_PM-KI-DB-SS-ID-00_YYYY-MM-DDTHH-MM-SS.16800')
+
+        attack = AttackPMKID(target, realtime_crack_manager=mock_rt_manager)
+        
+        # Patch the save_pmkid method within the instance for this test
+        # to control the returned filename and avoid actual file system operations for saving.
+        with patch.object(attack, 'save_pmkid', return_value=expected_pmkid_filepath) as mock_save:
+            with patch('time.sleep'): # Patch time.sleep to speed up loops
+                attack.run()
+
+            mock_save.assert_called_once_with(test_pmkid_hash_string)
+        
+        # Assert that start_target_crack_session was called on the manager
+        mock_rt_manager.start_target_crack_session.assert_called_once_with(
+            target_bssid=target.bssid,
+            essid=target.essid,
+            hash_file_path=expected_pmkid_filepath,
+            hash_type=16800
+        )
+        
+        # Since we mocked crack_pmkid, and real-time is started,
+        # the .success might depend on whether run() considers starting RT as success
+        # The current run() returns True if PMKID is captured.
+        self.assertTrue(attack.run()) # Re-check based on current logic
+
+if __name__ == '__main__':
+    # Need to ensure Configuration is initialized for standalone runs if not using a test runner
+    # For simplicity, this is often handled by running tests via `python -m unittest discover`
+    # or specific test runner configurations.
+    if not hasattr(Configuration, 'temp_dir'): # Basic check
+        Configuration.initialize(load_yaml=False)
+        Configuration.temp_dir = '/tmp/wifite_test_temp_pmkid_main'
+        if not os.path.exists(Configuration.temp_dir):
+            os.makedirs(Configuration.temp_dir)
+
+    unittest.main()

--- a/tests/attack/test_AttackWPA.py
+++ b/tests/attack/test_AttackWPA.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import Mock, patch
+
+# Adjust import paths based on Wifite's structure
+# This assumes Wifite can be imported if tests are run from the project root
+from wifite.attack.wpa import AttackWPA
+from wifite.model.target import Target
+from wifite.util.color import Color
+from wifite.config import Configuration
+
+class TestAttackWPA(unittest.TestCase):
+
+    def setUp(self):
+        # Basic configuration mock needed for some functions called within AttackWPA
+        # We might not need all of these, but it's good to have a base.
+        Configuration.initialize(load_yaml=False) # Avoid loading external config
+        Configuration.wordlist = None # Ensure no cracking is attempted
+        Configuration.wps_only = False
+        Configuration.use_pmkid_only = False
+        Configuration.no_deauth = True # Avoid actual deauth calls
+
+    @patch('sys.stdout', new_callable=unittest.mock.StringIO) # Capture stdout
+    def test_run_on_wpa3_target(self, mock_stdout):
+        '''Test AttackWPA.run() with a WPA3 target.'''
+        # Mock a Target object that identifies as WPA3
+        mock_target_wpa3_fields = ['W3:MA:CA:DD:RE:SS', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '1201', 'WPA3 PSK', 'GCMP', 'SAE', '-40', '10', '0', '0.0.0.0', '8', 'WPA3Test', '']
+        target_wpa3 = Target(mock_target_wpa3_fields)
+        # Ensure is_wpa3 is explicitly True as per Target class logic
+        self.assertTrue(target_wpa3.is_wpa3) 
+
+        attack = AttackWPA(target_wpa3)
+        
+        # Since AttackWPA.run() involves complex interactions (airodump, aireplay),
+        # we focus on the initial WPA3 check.
+        # The run method should return False early for WPA3.
+        result = attack.run()
+        self.assertFalse(result, "AttackWPA.run() should return False for WPA3 targets.")
+
+        # Check if the informational message was printed
+        output = mock_stdout.getvalue()
+        expected_msg_part = "Target WPA3Test is WPA3-SAE. Traditional 4-way handshake capture is ineffective."
+        self.assertIn(expected_msg_part, Color.strip(output), "WPA3 warning message not found in stdout.")
+
+    # We can add a test for WPA2 targets to ensure it tries to proceed,
+    # but that would involve more mocking of Airodump, Handshake, etc.
+    # For this subtask, focusing on the WPA3 branch is key.
+    
+    @patch('wifite.attack.wpa.AttackWPA.capture_handshake', return_value=None) # Mock handshake capture to prevent it from running
+    @patch('wifite.util.color.Color.pl') # Mock Color.pl to check calls
+    def test_run_on_wpa2_target_proceeds(self, mock_color_pl, mock_capture_handshake):
+        '''Test AttackWPA.run() with a WPA2 target to ensure it proceeds (superficially).'''
+        mock_target_wpa2_fields = ['W2:MA:CA:DD:RE:SS', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '6', '300', 'WPA2', 'CCMP', 'PSK', '-50', '10', '0', '0.0.0.0', '8', 'WPA2Test', '']
+        target_wpa2 = Target(mock_target_wpa2_fields)
+        self.assertFalse(target_wpa2.is_wpa3)
+
+        attack = AttackWPA(target_wpa2)
+        
+        # We've mocked capture_handshake to return None, so it should fail there.
+        # The key is that it didn't exit due to WPA3 check.
+        result = attack.run()
+        self.assertFalse(result) # It will be False because capture_handshake returns None
+
+        # Check that the WPA3 warning was NOT printed.
+        # We check calls to Color.pl to see if the WPA3 message was among them.
+        wpa3_warning_printed = False
+        for call_args in mock_color_pl.call_args_list:
+            if "is WPA3-SAE" in call_args[0][0]:
+                wpa3_warning_printed = True
+                break
+        self.assertFalse(wpa3_warning_printed, "WPA3 warning should not be printed for a WPA2 target.")
+
+    @patch('wifite.attack.wpa.Handshake') # Mock the Handshake object operations
+    @patch('wifite.tools.hashcat.HcxPcapTool.generate_hccapx_file') # Mock .hccapx generation
+    @patch('wifite.tools.aircrack.Aircrack.crack_handshake') # Mock aircrack-ng cracking
+    @patch('os.path.exists', return_value=True) # Assume files exist
+    def test_run_starts_realtime_crack_on_wpa2_target_if_enabled(self, mock_path_exists, mock_aircrack_crack, mock_gen_hccapx, MockHandshake):
+        Configuration.hashcat_realtime = True
+        Configuration.wordlist = None # Don't proceed to local aircrack cracking for this specific test focus
+
+        # Mock target
+        mock_target_wpa2_fields = ['W2:RT:CA:DD:RE:SS', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '6', '300', 'WPA2', 'CCMP', 'PSK', '-50', '10', '0', '0.0.0.0', '10', 'WPA2RealTm', '']
+        target_wpa2 = Target(mock_target_wpa2_fields)
+        self.assertFalse(target_wpa2.is_wpa3)
+
+        # Mock RealtimeCrackManager
+        mock_rt_manager = MagicMock()
+        mock_rt_manager.is_actively_cracking.return_value = False
+        mock_rt_manager.get_cracked_password.return_value = None
+        
+        attack = AttackWPA(target_wpa2, realtime_crack_manager=mock_rt_manager)
+
+        # Mock capture_handshake to return a mock Handshake object
+        mock_handshake_obj = MockHandshake.return_value
+        mock_handshake_obj.capfile = '/tmp/fake_handshake.cap' # Used by generate_hccapx_file
+        mock_handshake_obj.bssid = target_wpa2.bssid
+        mock_handshake_obj.essid = target_wpa2.essid
+        mock_handshake_obj.has_handshake.return_value = True # Simulate successful capture
+        
+        with patch.object(attack, 'capture_handshake', return_value=mock_handshake_obj) as mock_capture:
+            # Mock generate_hccapx_file to return a predictable path
+            expected_hccapx_path = '/tmp/generated_for_realtime.hccapx'
+            mock_gen_hccapx.return_value = expected_hccapx_path
+            
+            # Mock save_handshake as it's called after capture
+            with patch.object(attack, 'save_handshake') as mock_save_hs:
+                attack.run()
+        
+        mock_capture.assert_called_once()
+        mock_gen_hccapx.assert_called_once_with(mock_handshake_obj)
+        
+        # Assert that start_target_crack_session was called on the manager
+        mock_rt_manager.start_target_crack_session.assert_called_once_with(
+            target_bssid=target_wpa2.bssid,
+            essid=target_wpa2.essid,
+            hash_file_path=expected_hccapx_path,
+            hash_type=2500 # WPA/WPA2 HCCAPX
+        )
+        # The run method will return False because Configuration.wordlist is None,
+        # preventing aircrack-ng from running and thus not finding a key.
+        self.assertFalse(attack.success)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_Target.py
+++ b/tests/test_Target.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from wifite.tools.airodump import Airodump
+from wifite.model.target import Target # Import Target class directly
+from wifite.util.color import Color # For testing to_str() output
 
 import unittest
 
@@ -30,6 +32,109 @@ class TestTarget(unittest.TestCase):
         for t in targets:
             if t.bssid == '00:1D:D5:9B:11:00':
                 assert(len(t.clients) > 0)
+
+    def test_wpa3_parsing(self):
+        '''Tests parsing of WPA3 networks'''
+        # BSSID, First time seen, Last time seen, channel, Speed, Privacy, Cipher, Authentication, Power, beacons, # IV, LAN IP, ID-length, ESSID, Key
+        row_wpa3 = ['AA:BB:CC:DD:EE:FF', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '6', '300', 'WPA3 OWE', 'GCMP', 'SAE', '-50', '10', '0', '0.0.0.0', '4', 'WPA3NET', '']
+        target = Target(row_wpa3)
+        self.assertTrue(target.is_wpa3)
+        self.assertFalse(target.is_owe) # OWE is in privacy but WPA3 takes precedence for is_wpa3, encryption should be WPA3
+        self.assertEqual(target.encryption, 'WPA3')
+
+        row_wpa2_wpa3 = ['AA:BB:CC:DD:EE:FE', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '300', 'WPA3 WPA2', 'GCMP CCMP', 'PSK SAE', '-55', '10', '0', '0.0.0.0', '9', 'MIXEDMODE', '']
+        target_mixed = Target(row_wpa2_wpa3)
+        self.assertTrue(target_mixed.is_wpa3)
+        self.assertEqual(target_mixed.encryption, 'WPA3') # WPA3 should be preferred
+
+    def test_owe_parsing(self):
+        '''Tests parsing of OWE networks'''
+        row_owe = ['AA:BB:CC:DD:EE:FD', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '11', '300', 'OWE', 'GCMP', 'OWE', '-60', '10', '0', '0.0.0.0', '7', 'OWENET', '']
+        target = Target(row_owe)
+        self.assertFalse(target.is_wpa3)
+        self.assertTrue(target.is_owe)
+        self.assertEqual(target.encryption, 'OWE')
+
+    def test_wifi_standard_parsing(self):
+        '''Tests inference of Wi-Fi standards (ax, be, ac, n, g, b)'''
+        # Test BE (Wi-Fi 7)
+        row_be = ['BE:BE:BE:BE:BE:BE', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '36', '6000', 'WPA3', 'GCMP', 'SAE', '-40', '10', '0', '0.0.0.0', '3', 'BE', '']
+        target = Target(row_be)
+        self.assertEqual(target.wifi_standard, 'be')
+
+        # Test AX (Wi-Fi 6)
+        row_ax = ['AX:AX:AX:AX:AX:AX', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '1201', 'WPA3', 'GCMP', 'SAE', '-45', '10', '0', '0.0.0.0', '3', 'AX', '']
+        target = Target(row_ax)
+        self.assertEqual(target.wifi_standard, 'ax')
+        
+        row_ax_high = ['AX:AX:AX:AX:AX:A1', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '2402', 'WPA3', 'GCMP', 'SAE', '-45', '10', '0', '0.0.0.0', '3', 'AX2', '']
+        target = Target(row_ax_high)
+        self.assertEqual(target.wifi_standard, 'ax')
+
+        # Test AC (Wi-Fi 5)
+        row_ac = ['AC:AC:AC:AC:AC:AC', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '40', '866', 'WPA2', 'CCMP', 'PSK', '-50', '10', '0', '0.0.0.0', '3', 'AC', '']
+        target = Target(row_ac)
+        self.assertEqual(target.wifi_standard, 'ac')
+        
+        # Test N (high speed)
+        row_n_high = ['N0:N0:N0:N0:N0:N0', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '11', '300', 'WPA2', 'CCMP', 'PSK', '-55', '10', '0', '0.0.0.0', '4', 'N300', '']
+        target = Target(row_n_high)
+        self.assertEqual(target.wifi_standard, 'ac') # Current logic pushes >=300 to 'ac'
+
+        row_n_low = ['N1:N1:N1:N1:N1:N1', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '6', '144', 'WPA2', 'CCMP', 'PSK', '-58', '10', '0', '0.0.0.0', '3', 'N144', '']
+        target = Target(row_n_low)
+        self.assertEqual(target.wifi_standard, 'n')
+
+        # Test G
+        row_g = ['GG:GG:GG:GG:GG:GG', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '54', 'WPA2', 'TKIP', 'PSK', '-60', '10', '0', '0.0.0.0', '1', 'G', '']
+        target = Target(row_g)
+        self.assertEqual(target.wifi_standard, 'g')
+        
+        # Test G with QoS (should be upgraded to N by current logic)
+        row_g_qos = ['GQ:GQ:GQ:GQ:GQ:GQ', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '54e', 'WPA2', 'TKIP', 'PSK', '-60', '10', '0', '0.0.0.0', '3', 'GQE', '']
+        target = Target(row_g_qos)
+        self.assertEqual(target.wifi_standard, 'n')
+
+
+        # Test B
+        row_b = ['BB:BB:BB:BB:BB:BB', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '11', '11', 'WEP', 'WEP', '', '-70', '10', '0', '0.0.0.0', '1', 'B', '']
+        target = Target(row_b)
+        self.assertEqual(target.wifi_standard, 'b')
+
+    def test_target_to_str_formatting(self):
+        '''Tests the to_str() method for new WPA3/OWE/Wi-Fi standard indicators'''
+        # WPA3-SAE and AX
+        row_wpa3_ax = ['AX:AX:AX:AX:AX:AX', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '1', '1201', 'WPA3', 'GCMP', 'SAE', '-45', '10', '0', '0.0.0.0', '6', 'WPA3AX', '']
+        target_wpa3_ax = Target(row_wpa3_ax)
+        target_str = Color.strip(target_wpa3_ax.to_str()) # Strip color codes for simple substring check
+        self.assertIn('[AX]', target_str)
+        self.assertIn('WPA3', target_str) # Encryption field
+
+        # OWE and AC
+        row_owe_ac = ['AC:AC:AC:AC:AC:AC', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '40', '866', 'OWE', 'GCMP', 'OWE', '-50', '10', '0', '0.0.0.0', '6', 'OWE-AC', '']
+        target_owe_ac = Target(row_owe_ac)
+        target_str_owe = Color.strip(target_owe_ac.to_str())
+        self.assertIn('[AC]', target_str_owe)
+        self.assertIn('OWE', target_str_owe)
+        
+        # BE standard
+        row_be = ['BE:BE:BE:BE:BE:BE', '2023-01-01 10:00:00', '2023-01-01 10:00:00', '36', '7000', 'WPA3', 'GCMP', 'SAE', '-40', '10', '0', '0.0.0.0', '6', 'WIFI7', '']
+        target_be = Target(row_be)
+        target_str_be = Color.strip(target_be.to_str())
+        self.assertIn('[BE]', target_str_be)
+
+        # Check colors (more involved, might need specific color code checks if critical)
+        # For now, we assume the color codes used in to_str() are correct if the substrings are present.
+        # Example: WPA3 should be Red.
+        target_str_wpa3_color = target_wpa3_ax.to_str()
+        self.assertIn(Color.s('{R}WPA3'), target_str_wpa3_color) # Check if WPA3 is wrapped in Red color
+
+        target_str_owe_color = target_owe_ac.to_str()
+        self.assertIn(Color.s('{M} OWE'), target_str_owe_color) # Check if OWE is wrapped in Magenta (note space due to rjust(4))
+
+        target_str_ax_color = target_wpa3_ax.to_str()
+        self.assertIn(Color.s('{C}[AX]'), target_str_ax_color) # Check if [AX] is wrapped in Cyan
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_realtime_crack_manager.py
+++ b/tests/test_realtime_crack_manager.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+
+# Assuming wifite is in PYTHONPATH or tests are run from project root
+from wifite.realtime_crack_manager import RealtimeCrackManager
+from wifite.tools.hashcat import RealtimeHashcatSession # Needed for type hinting and mocking
+from wifite.config import Configuration
+from wifite.util.color import Color # To check if Color.pl is called, not for asserting color codes
+
+# Mock a basic Configuration object for tests
+mock_config = MagicMock()
+mock_config.hashcat_realtime = True
+mock_config.hashcat_realtime_wordlist_file = None
+mock_config.hashcat_realtime_wordlist_dir = '/fake/wordlist_dir'
+mock_config.hashcat_realtime_options = None
+mock_config.hashcat_realtime_force_cpu = False
+mock_config.hashcat_realtime_gpu_devices = None
+mock_config.temp = lambda x: os.path.join('/tmp/wifite_test_temp', x) # Mock temp dir
+mock_config.verbose = 0 # Default verbosity
+
+class TestRealtimeCrackManager(unittest.TestCase):
+
+    def setUp(self):
+        # Reset parts of the mock_config that might be changed by tests
+        Configuration.hashcat_realtime = True
+        Configuration.hashcat_realtime_wordlist_file = None
+        Configuration.hashcat_realtime_wordlist_dir = '/fake/wordlist_dir'
+        Configuration.hashcat_realtime_options = None
+        Configuration.hashcat_realtime_force_cpu = False
+        Configuration.hashcat_realtime_gpu_devices = None
+        Configuration.temp_dir = '/tmp/wifite_test_temp' # Used by Configuration.temp()
+        if not os.path.exists(Configuration.temp_dir):
+            os.makedirs(Configuration.temp_dir)
+
+        # Patch os.path.exists globally for this test class for simplicity,
+        # specific tests can override its side_effect if needed.
+        self.patcher_os_path_exists = patch('os.path.exists')
+        self.mock_os_path_exists = self.patcher_os_path_exists.start()
+        self.mock_os_path_exists.return_value = True # Default to files/dirs existing
+
+        self.patcher_os_path_isfile = patch('os.path.isfile')
+        self.mock_os_path_isfile = self.patcher_os_path_isfile.start()
+        self.mock_os_path_isfile.return_value = True
+
+        self.patcher_os_path_isdir = patch('os.path.isdir')
+        self.mock_os_path_isdir = self.patcher_os_path_isdir.start()
+        self.mock_os_path_isdir.return_value = True
+        
+        self.patcher_os_path_getsize = patch('os.path.getsize')
+        self.mock_os_path_getsize = self.patcher_os_path_getsize.start()
+        self.mock_os_path_getsize.return_value = 100 # Default to non-empty
+
+        self.patcher_os_listdir = patch('os.listdir')
+        self.mock_os_listdir = self.patcher_os_listdir.start()
+
+        self.patcher_color_pl = patch('wifite.util.color.Color.pl')
+        self.mock_color_pl = self.patcher_color_pl.start()
+        
+        self.manager = RealtimeCrackManager(Configuration)
+
+    def tearDown(self):
+        self.patcher_os_path_exists.stop()
+        self.patcher_os_path_isfile.stop()
+        self.patcher_os_path_isdir.stop()
+        self.patcher_os_path_getsize.stop()
+        self.patcher_os_listdir.stop()
+        self.patcher_color_pl.stop()
+        # Clean up temp dir
+        if os.path.exists(Configuration.temp_dir):
+            import shutil
+            shutil.rmtree(Configuration.temp_dir)
+
+
+    def test_load_wordlists_single_file_valid(self):
+        Configuration.hashcat_realtime_wordlist_file = '/fake/wordlist.txt'
+        Configuration.hashcat_realtime_wordlist_dir = None # Ensure dir is not used
+        self.manager._load_wordlists()
+        self.assertEqual(len(self.manager.wordlist_queue), 1)
+        self.assertEqual(self.manager.wordlist_queue[0], '/fake/wordlist.txt')
+
+    def test_load_wordlists_single_file_invalid(self):
+        Configuration.hashcat_realtime_wordlist_file = '/fake/nonexistent.txt'
+        self.mock_os_path_exists.side_effect = lambda x: False if x == '/fake/nonexistent.txt' else True
+        self.manager._load_wordlists()
+        self.assertEqual(len(self.manager.wordlist_queue), 0)
+        self.mock_color_pl.assert_any_call(f"{{R}}Real-time: Specified wordlist file {{O}}{Configuration.hashcat_realtime_wordlist_file}{{R}} not found or empty.{W}")
+
+    def test_load_wordlists_directory_valid_multiple_files(self):
+        Configuration.hashcat_realtime_wordlist_dir = '/fake/wordlist_dir'
+        Configuration.hashcat_realtime_wordlist_file = None
+        self.mock_os_listdir.return_value = ['wl1.txt', 'wl2.lst', 'some.potfile']
+        # os.path.isfile needs to be True for these paths
+        self.mock_os_path_isfile.side_effect = lambda x: x.endswith(('.txt', '.lst'))
+        
+        self.manager._load_wordlists()
+        self.assertEqual(len(self.manager.wordlist_queue), 2)
+        self.assertIn(os.path.join('/fake/wordlist_dir', 'wl1.txt'), self.manager.wordlist_queue)
+        self.assertIn(os.path.join('/fake/wordlist_dir', 'wl2.lst'), self.manager.wordlist_queue)
+        self.assertNotIn(os.path.join('/fake/wordlist_dir', 'some.potfile'), self.manager.wordlist_queue)
+
+    def test_load_wordlists_directory_empty(self):
+        Configuration.hashcat_realtime_wordlist_dir = '/fake/empty_dir'
+        Configuration.hashcat_realtime_wordlist_file = None
+        self.mock_os_listdir.return_value = []
+        self.manager._load_wordlists()
+        self.assertEqual(len(self.manager.wordlist_queue), 0)
+        self.mock_color_pl.assert_any_call(f"{{R}}Real-time: No valid wordlists found. Real-time cracking disabled for this target.{W}")
+
+    def test_load_wordlists_directory_invalid(self):
+        Configuration.hashcat_realtime_wordlist_dir = '/fake/invalid_dir'
+        Configuration.hashcat_realtime_wordlist_file = None
+        self.mock_os_path_isdir.side_effect = lambda x: False if x == '/fake/invalid_dir' else True
+        self.manager._load_wordlists()
+        self.assertEqual(len(self.manager.wordlist_queue), 0)
+        self.mock_color_pl.assert_any_call(f"{{R}}Real-time: Wordlist directory {{O}}{Configuration.hashcat_realtime_wordlist_dir}{{R}} not found.{W}")
+
+    @patch.object(RealtimeCrackManager, '_load_wordlists')
+    @patch.object(RealtimeCrackManager, '_try_next_wordlist')
+    @patch.object(RealtimeCrackManager, 'stop_current_crack_attempt')
+    def test_start_target_crack_session(self, mock_stop, mock_try_next, mock_load_wl):
+        self.manager.active_session = MagicMock() # Simulate an existing session
+        self.manager.start_target_crack_session('NEW_BSSID', 'NewESSID', '/path/to/hash2.txt', 16800)
+        
+        mock_stop.assert_called_once_with(cleanup_hash_file=True)
+        self.assertEqual(self.manager.current_target_bssid, 'NEW_BSSID')
+        self.assertEqual(self.manager.current_hash_file_path, '/path/to/hash2.txt')
+        self.assertEqual(self.manager.current_hash_type, 16800)
+        mock_load_wl.assert_called_once()
+        mock_try_next.assert_called_once()
+
+    @patch('wifite.tools.hashcat.Hashcat.start_realtime_crack')
+    @patch.object(RealtimeCrackManager, 'stop_current_crack_attempt')
+    def test_try_next_wordlist_starts_session(self, mock_stop_current, mock_start_hashcat):
+        self.manager.wordlist_queue = ['/fake/wl1.txt']
+        self.manager.current_target_bssid = 'TARGET_BSSID'
+        self.manager.current_hash_file_path = '/path/to/hash.txt'
+        self.manager.current_hash_type = 2500
+        
+        mock_session_obj = MagicMock(spec=RealtimeHashcatSession)
+        mock_start_hashcat.return_value = mock_session_obj
+
+        self.manager._try_next_wordlist()
+
+        mock_start_hashcat.assert_called_once_with(
+            'TARGET_BSSID', '/path/to/hash.txt', 2500, '/fake/wl1.txt',
+            user_hashcat_options=[], user_preferences={}
+        )
+        self.assertEqual(self.manager.active_session, mock_session_obj)
+        self.assertEqual(self.manager.current_wordlist_path, '/fake/wl1.txt')
+        mock_stop_current.assert_not_called() # Should not be called if session starts
+
+    @patch('wifite.tools.hashcat.Hashcat.start_realtime_crack')
+    @patch.object(RealtimeCrackManager, 'stop_current_crack_attempt')
+    def test_try_next_wordlist_no_wordlists(self, mock_stop_current, mock_start_hashcat):
+        self.manager.wordlist_queue = []
+        self.manager.current_target_bssid = 'TARGET_BSSID'
+        self.manager.current_hash_file_path = '/path/to/temp_hash.txt' # Assume temp for cleanup check
+        Configuration.temp_dir = '/tmp' # ensure temp path check works
+        
+        self.manager._try_next_wordlist()
+        
+        mock_start_hashcat.assert_not_called()
+        mock_stop_current.assert_called_once_with(cleanup_hash_file=True) # True because hash file is temp
+
+    @patch('wifite.tools.hashcat.Hashcat.start_realtime_crack', return_value=None)
+    @patch.object(RealtimeCrackManager, '_try_next_wordlist') # Mock to prevent recursion in this test
+    def test_try_next_wordlist_hashcat_start_fails(self, mock_recursive_try_next, mock_start_hashcat):
+        self.manager.wordlist_queue = ['/fake/wl1.txt', '/fake/wl2.txt']
+        self.manager.current_target_bssid = 'TARGET_BSSID'
+        self.manager.current_hash_file_path = '/path/to/hash.txt'
+        self.manager.current_hash_type = 2500
+        initial_errors = self.manager.consecutive_hashcat_errors
+
+        self.manager._try_next_wordlist() # This will call mock_start_hashcat which returns None
+        
+        self.assertEqual(self.manager.consecutive_hashcat_errors, initial_errors + 1)
+        self.mock_color_pl.assert_any_call(f"{{R}}Real-time: Failed to start Hashcat with wordlist {{O}}{os.path.basename('/fake/wl1.txt')}{{R}} for {{C}}TARGET_BSSID{W}")
+        mock_recursive_try_next.assert_called_once() # Checks if it tries the next list
+
+    def test_update_status_no_active_session(self):
+        self.manager.active_session = None
+        result = self.manager.update_status()
+        self.assertIsNone(result)
+
+    @patch('wifite.tools.hashcat.Hashcat.check_realtime_crack_status')
+    @patch('wifite.model.wpa_result.CrackResultWPA.dump') # Mock save to avoid actual file IO
+    @patch.object(RealtimeCrackManager, 'stop_current_crack_attempt')
+    def test_update_status_password_cracked(self, mock_stop_attempt, mock_dump, mock_check_status):
+        mock_session = MagicMock(spec=RealtimeHashcatSession)
+        mock_session.hash_file_path = '/path/to/hashfile.hccapx' # Needed for CrackResultWPA
+        self.manager.active_session = mock_session
+        self.manager.current_target_bssid = 'CRACKED_BSSID'
+        self.manager.current_target_essid = 'CrackedESSID'
+        self.manager.current_hash_type = 2500
+
+        mock_check_status.return_value = {
+            'status_lines': ['Some status'],
+            'cracked_password': 'the_password',
+            'is_process_complete': True, # Typically true when password found
+            'error_lines': []
+        }
+
+        result_bssid, result_password = self.manager.update_status()
+        
+        self.assertEqual(result_bssid, 'CRACKED_BSSID')
+        self.assertEqual(result_password, 'the_password')
+        self.mock_color_pl.assert_any_call(f"{{G}}SUCCESS: Real-time crack for {{C}}CRACKED_BSSID{{G}} (ESSID: CrackedESSID)! Password: {{R}}the_password{{W}}")
+        mock_dump.assert_called_once()
+        self.assertEqual(self.manager.realtime_cracked_passwords['CRACKED_BSSID'], 'the_password')
+        mock_stop_attempt.assert_called_once()
+
+
+    @patch('wifite.tools.hashcat.Hashcat.check_realtime_crack_status')
+    @patch('wifite.tools.hashcat.Hashcat.stop_realtime_crack') # Mock this directly for this test
+    @patch.object(RealtimeCrackManager, '_try_next_wordlist')
+    def test_update_status_process_complete_no_password(self, mock_try_next, mock_hashcat_stop, mock_check_status):
+        mock_session = MagicMock(spec=RealtimeHashcatSession)
+        self.manager.active_session = mock_session
+        self.manager.current_target_bssid = 'TARGET_BSSID'
+        self.manager.current_wordlist_path = '/fake/wl_exhausted.txt'
+
+        mock_check_status.return_value = {
+            'status_lines': ['Exhausted'],
+            'cracked_password': None,
+            'is_process_complete': True,
+            'error_lines': []
+        }
+
+        result = self.manager.update_status()
+        self.assertIsNone(result)
+        self.mock_color_pl.assert_any_call(f"{{G}}Real-time: Wordlist {{C}}{os.path.basename('/fake/wl_exhausted.txt')}{{W}} exhausted for {{C}}TARGET_BSSID{W}.")
+        mock_hashcat_stop.assert_called_once_with(mock_session, cleanup_hash_file=False)
+        self.assertIsNone(self.manager.active_session) # Should be cleared
+        mock_try_next.assert_called_once()
+
+    @patch('wifite.tools.hashcat.Hashcat.stop_realtime_crack')
+    def test_stop_current_crack_attempt(self, mock_hashcat_stop):
+        mock_session = MagicMock(spec=RealtimeHashcatSession)
+        mock_session.hash_file_path = os.path.join(Configuration.temp_dir, "temp_hash.16800") # Temp file
+        self.manager.active_session = mock_session
+        self.manager.current_target_bssid = 'ANY_BSSID'
+        self.manager.current_hash_file_path = mock_session.hash_file_path
+        
+        self.manager.stop_current_crack_attempt(cleanup_hash_file=True)
+        
+        mock_hashcat_stop.assert_called_once_with(mock_session, cleanup_hash_file=True)
+        self.assertIsNone(self.manager.active_session)
+        self.assertIsNone(self.manager.current_target_bssid) # Cleared because cleanup_hash_file was true
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wifite/args.py
+++ b/wifite/args.py
@@ -32,10 +32,45 @@ class Arguments(object):
         self._add_wpa_args(parser.add_argument_group(Color.s('{C}WPA{W}')))
         self._add_wps_args(parser.add_argument_group(Color.s('{C}WPS{W}')))
         self._add_pmkid_args(parser.add_argument_group(Color.s('{C}PMKID{W}')))
+        self._add_hashcat_realtime_args(parser.add_argument_group(Color.s('{C}REALTIME HASHCAT{W}')))
         self._add_eviltwin_args(parser.add_argument_group(Color.s('{C}EVIL TWIN{W}')))
         self._add_command_args(parser.add_argument_group(Color.s('{C}COMMANDS{W}')))
 
         return parser.parse_args()
+
+    def _add_hashcat_realtime_args(self, hrt):
+        hrt.add_argument('--hashcat-realtime',
+            action='store_true',
+            dest='hashcat_realtime',
+            help=Color.s('Enable real-time Hashcat cracking for captured PMKIDs and WPA handshakes (default: {G}off{W})'))
+        hrt.add_argument('--hashcat-realtime-wordlist-dir',
+            action='store',
+            dest='hashcat_realtime_wordlist_dir',
+            metavar='<directory>',
+            default='/usr/share/wordlists/', # Sensible default
+            help=Color.s('Directory of wordlists for real-time Hashcat cracking (default: {G}/usr/share/wordlists/{W})'))
+        hrt.add_argument('--hashcat-realtime-wordlist-file',
+            action='store',
+            dest='hashcat_realtime_wordlist_file',
+            metavar='<file>',
+            default=None,
+            help=Color.s('Specific wordlist file for real-time Hashcat cracking (overrides directory search)'))
+        hrt.add_argument('--hashcat-realtime-options',
+            action='store',
+            dest='hashcat_realtime_options',
+            metavar='<options_str>',
+            default=None,
+            help=Color.s('Custom options string for Hashcat real-time sessions (e.g., "--increment --increment-min=4")'))
+        hrt.add_argument('--hashcat-realtime-force-cpu',
+            action='store_true',
+            dest='hashcat_realtime_force_cpu',
+            help=Color.s('Force Hashcat to use CPU for real-time cracking (adds --force and device type CPU) (default: {G}off{W})'))
+        hrt.add_argument('--hashcat-realtime-gpu-devices',
+            action='store',
+            dest='hashcat_realtime_gpu_devices',
+            metavar='<ids_str>',
+            default=None,
+            help=Color.s('GPU device IDs for Hashcat real-time (e.g., "1,3" for --opencl-device-types 2 --opencl-device-ids 1,3) (default: {G}Hashcat auto{W})'))
 
 
     def _add_global_args(self, glob):

--- a/wifite/attack/wpa.py
+++ b/wifite/attack/wpa.py
@@ -18,8 +18,9 @@ import re
 from shutil import copy
 
 class AttackWPA(Attack):
-    def __init__(self, target):
+    def __init__(self, target, realtime_crack_manager=None):
         super(AttackWPA, self).__init__(target)
+        self.realtime_crack_manager = realtime_crack_manager
         self.clients = []
         self.crack_result = None
         self.success = False
@@ -28,7 +29,7 @@ class AttackWPA(Attack):
         '''Initiates full WPA handshake capture attack.'''
 
         # Skip if target is not WPS
-        if Configuration.wps_only and self.target.wps == False:
+        if Configuration.wps_only and self.target.wps == False: # Assuming self.target.wps is a boolean or similar
             Color.pl('\r{!} {O}Skipping WPA-Handshake attack on {R}%s{O} because {R}--wps-only{O} is set{W}' % self.target.essid)
             self.success = False
             return self.success
@@ -37,6 +38,12 @@ class AttackWPA(Attack):
         if Configuration.use_pmkid_only:
             self.success = False
             return False
+
+        # Check for WPA3-SAE
+        if hasattr(self.target, 'is_wpa3') and self.target.is_wpa3:
+            Color.pl('\r{!} {O}Target {C}%s{O} is WPA3-SAE. Traditional 4-way handshake capture is ineffective. Prioritizing PMKID attack.{W}' % self.target.essid)
+            self.success = False # Indicate attack module is not suitable or did not run as a "success" for handshake cracking
+            return False # Exit gracefully
 
         # Capture the handshake (or use an old one)
         handshake = self.capture_handshake()
@@ -50,7 +57,34 @@ class AttackWPA(Attack):
         Color.pl('\n{+} analysis of captured handshake file:')
         handshake.analyze()
 
-        # Check wordlist
+        # If real-time cracking is enabled, try to start a session with the captured handshake.
+        if handshake and self.realtime_crack_manager and Configuration.hashcat_realtime:
+            # Convert .cap to .hccapx for Hashcat using HcxPcapTool
+            from ..tools.hashcat import HcxPcapTool # Import locally to avoid circular if not already loaded
+            try:
+                # handshake.capfile should point to the cleaned/saved handshake from self.save_handshake()
+                hccapx_file = HcxPcapTool.generate_hccapx_file(handshake)
+                if hccapx_file and os.path.exists(hccapx_file):
+                    if not self.realtime_crack_manager.is_actively_cracking(self.target.bssid) and \
+                       not self.realtime_crack_manager.get_cracked_password(self.target.bssid):
+                        Color.pl('{+} {G}Handshake captured. Starting real-time Hashcat cracking session with .hccapx.{W}')
+                        self.realtime_crack_manager.start_target_crack_session(
+                            target_bssid=self.target.bssid,
+                            essid=self.target.essid if self.target.essid_known else "ESSID_Unknown",
+                            hash_file_path=hccapx_file, # Path to the .hccapx file
+                            hash_type=2500 # Hashcat mode for WPA/WPA2 hccapx
+                        )
+                    elif self.realtime_crack_manager.get_cracked_password(self.target.bssid):
+                        Color.pl('{+} {G}Handshake captured, but target already cracked by real-time manager.{W}')
+                    elif self.realtime_crack_manager.is_actively_cracking(self.target.bssid):
+                        Color.pl('{+} {G}Handshake captured, real-time cracking already in progress for this target.{W}')
+                else:
+                    Color.pl('{!} {R}Failed to convert handshake to .hccapx format for real-time cracking.{W}')
+            except Exception as e:
+                Color.pl('{!} {R}Error during .hccapx conversion for real-time cracking: %s{W}' % str(e))
+
+
+        # Check wordlist for the traditional aircrack-ng attack
         if Configuration.wordlist is None:
             Color.pl('{!} {O}Not cracking handshake because' +
                      ' wordlist ({R}--dict{O}) is not set')

--- a/wifite/realtime_crack_manager.py
+++ b/wifite/realtime_crack_manager.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from .tools.hashcat import Hashcat, RealtimeHashcatSession # Assuming RealtimeHashcatSession is in hashcat.py
+from .util.color import Color
+from .config import Configuration # Assuming Configuration is accessible like this
+from .model.wpa_result import CrackResultWPA # For saving cracked results
+
+import os
+import time
+
+class RealtimeCrackManager:
+    def __init__(self, config):
+        self.config = config # Should be an instance of Configuration
+        self.active_session: RealtimeHashcatSession = None
+        self.current_target_bssid = None
+        self.current_hash_file_path = None # Path to the file Hashcat is currently working on
+        self.current_hash_type = None
+        self.wordlist_queue = []
+        self.current_wordlist_path = None
+        self.consecutive_hashcat_errors = 0
+        self.max_hashcat_errors = 3 # Stop trying after this many consecutive Hashcat start failures
+        # Stores BSSID:password for already cracked targets in this Wifite session by real-time cracker
+        self.realtime_cracked_passwords = {}
+
+    def _load_wordlists(self):
+        self.wordlist_queue = []
+        if Configuration.hashcat_realtime_wordlist_file:
+            if os.path.exists(Configuration.hashcat_realtime_wordlist_file) and \
+               os.path.getsize(Configuration.hashcat_realtime_wordlist_file) > 0:
+                self.wordlist_queue.append(Configuration.hashcat_realtime_wordlist_file)
+            else:
+                Color.pl(f"{{R}}Real-time: Specified wordlist file {{O}}{Configuration.hashcat_realtime_wordlist_file}{{R}} not found or empty.{W}")
+        elif Configuration.hashcat_realtime_wordlist_dir:
+            if os.path.isdir(Configuration.hashcat_realtime_wordlist_dir):
+                try:
+                    for filename in sorted(os.listdir(Configuration.hashcat_realtime_wordlist_dir)):
+                        filepath = os.path.join(Configuration.hashcat_realtime_wordlist_dir, filename)
+                        if os.path.isfile(filepath) and os.path.getsize(filepath) > 0:
+                            # Basic check: avoid adding .potfile, .out, .log etc.
+                            if not any(ext in filename.lower() for ext in ['.potfile', '.out', '.log', '.session', '.restore']):
+                                self.wordlist_queue.append(filepath)
+                except OSError as e:
+                    Color.pl(f"{{R}}Real-time: Error reading wordlist directory {{O}}{Configuration.hashcat_realtime_wordlist_dir}{{R}}: {e}{W}")
+            else:
+                Color.pl(f"{{R}}Real-time: Wordlist directory {{O}}{Configuration.hashcat_realtime_wordlist_dir}{{R}} not found.{W}")
+
+        if not self.wordlist_queue:
+            Color.pl(f"{{R}}Real-time: No valid wordlists found. Real-time cracking disabled for this target.{W}")
+
+    def start_target_crack_session(self, target_bssid: str, essid: str, hash_file_path: str, hash_type: int):
+        if not Configuration.hashcat_realtime:
+            return
+
+        if self.active_session and self.current_target_bssid == target_bssid:
+            Color.pl(f"{{G}}Real-time: Session already active for {{C}}{target_bssid}{W}")
+            return
+        
+        if self.active_session:
+            Color.pl(f"{{G}}Real-time: Stopping previous session for {{C}}{self.current_target_bssid}{{W}} to start new one for {{C}}{target_bssid}{W}")
+            self.stop_current_crack_attempt(cleanup_hash_file=True) # Cleanup if previous hash file was temp
+
+        Color.pl(f"{{G}}Real-time: Initiating crack session for {{C}}{target_bssid}{W} ({essid}) using hash file {{C}}{hash_file_path}{W}")
+        self.current_target_bssid = target_bssid
+        self.current_target_essid = essid # Store ESSID for saving results
+        self.current_hash_file_path = hash_file_path
+        self.current_hash_type = hash_type
+        
+        self._load_wordlists()
+        if not self.wordlist_queue: # No wordlists found
+            self.current_target_bssid = None # Clear target as we can't proceed
+            self.current_hash_file_path = None
+            return
+
+        self.consecutive_hashcat_errors = 0
+        self._try_next_wordlist()
+
+    def _try_next_wordlist(self):
+        if self.active_session: # Should not happen if called correctly
+            Color.pl(f"{{R}}Real-time: _try_next_wordlist called while a session is active. This is a bug.{W}")
+            self.stop_current_crack_attempt(cleanup_hash_file=False) # Don't clean main hash, but stop session
+
+        if not self.wordlist_queue:
+            Color.pl(f"{{G}}Real-time: All wordlists exhausted for {{C}}{self.current_target_bssid}{W}")
+            # Determine if the main hash file for this target was temporary (e.g. single PMKID string)
+            cleanup_main_hash = self.current_hash_file_path and self.current_hash_file_path.startswith(Configuration.temp())
+            self.stop_current_crack_attempt(cleanup_hash_file=cleanup_main_hash)
+            return
+
+        if self.consecutive_hashcat_errors >= self.max_hashcat_errors:
+            Color.pl(f"{{R}}Real-time: Exceeded max Hashcat start errors ({self.max_hashcat_errors}) for {{C}}{self.current_target_bssid}{W}. Aborting real-time crack for this target.{W}")
+            cleanup_main_hash = self.current_hash_file_path and self.current_hash_file_path.startswith(Configuration.temp())
+            self.stop_current_crack_attempt(cleanup_hash_file=cleanup_main_hash)
+            return
+
+        self.current_wordlist_path = self.wordlist_queue.pop(0)
+        Color.pl(f"{{G}}Real-time: Trying wordlist {{C}}{os.path.basename(self.current_wordlist_path)}{{W}} for {{C}}{self.current_target_bssid}{W} ({len(self.wordlist_queue)} remaining)")
+
+        user_prefs = {}
+        if Configuration.hashcat_realtime_force_cpu:
+            user_prefs['force'] = True
+            user_prefs['opencl_device_types'] = '1' # CPU
+        elif Configuration.hashcat_realtime_gpu_devices:
+            user_prefs['opencl_device_types'] = '2' # GPU
+            user_prefs['opencl_device_ids'] = Configuration.hashcat_realtime_gpu_devices
+        
+        custom_options = Configuration.hashcat_realtime_options.split() if Configuration.hashcat_realtime_options else []
+
+        self.active_session = Hashcat.start_realtime_crack(
+            self.current_target_bssid, 
+            self.current_hash_file_path, 
+            self.current_hash_type, 
+            self.current_wordlist_path,
+            user_hashcat_options=custom_options,
+            user_preferences=user_prefs
+        )
+
+        if self.active_session is None:
+            self.consecutive_hashcat_errors += 1
+            Color.pl(f"{{R}}Real-time: Failed to start Hashcat with wordlist {{O}}{os.path.basename(self.current_wordlist_path)}{{R}} for {{C}}{self.current_target_bssid}{W}")
+            self._try_next_wordlist() # Try next one immediately
+
+    def update_status(self):
+        if not self.active_session or not Configuration.hashcat_realtime:
+            return None
+
+        status_info = Hashcat.check_realtime_crack_status(self.active_session)
+
+        for line in status_info['status_lines']:
+            # Filter out common verbose lines unless very high verbosity is set
+            if "STATUS" in line.upper() or "SPEED" in line.upper() or \
+               "PROGRESS" in line.upper() or "RECOVERED" in line.upper() or \
+               "REJECTED" in line.upper() or "EXHAUSTED" in line.upper() or \
+               Configuration.verbose > 2:
+                Color.pl(f"{{G}}Real-time Hashcat ({os.path.basename(self.current_wordlist_path)}): {{W}}{line.strip()}{W}")
+
+        for line in status_info['error_lines']:
+            Color.pl(f"{{R}}Real-time Hashcat ERROR ({os.path.basename(self.current_wordlist_path)}): {{O}}{line.strip()}{W}")
+
+        if status_info['cracked_password']:
+            password = status_info['cracked_password']
+            Color.pl(f"{{G}}SUCCESS: Real-time crack for {{C}}{self.current_target_bssid}{{G}} (ESSID: {self.current_target_essid})! Password: {{R}}{password}{{W}}")
+            
+            # Use CrackResultWPA for consistency in saving
+            crack_result = CrackResultWPA(
+                bssid=self.current_target_bssid,
+                essid=self.current_target_essid,
+                handshake_file=self.active_session.hash_file_path, # This might be .hccapx or PMKID file
+                key=password,
+                attack_type="PMKID-Realtime" if self.current_hash_type == 16800 else "WPA-Realtime"
+            )
+            crack_result.dump() # Saves to cracked.json and cracked.txt
+
+            self.realtime_cracked_passwords[self.current_target_bssid] = password
+            # Determine if the main hash file that was cracked should be cleaned up
+            cleanup_main_hash = self.current_hash_file_path and self.current_hash_file_path.startswith(Configuration.temp())
+            self.stop_current_crack_attempt(cleanup_hash_file=cleanup_main_hash)
+            return self.current_target_bssid, password # Signal success
+
+        elif status_info['is_process_complete']:
+            Color.pl(f"{{G}}Real-time: Wordlist {{C}}{os.path.basename(self.current_wordlist_path)}{{W}} exhausted for {{C}}{self.current_target_bssid}{W}.")
+            # Stop the session (cleans up session-specific pot/out files), but don't clean the main hash_file_path yet
+            Hashcat.stop_realtime_crack(self.active_session, cleanup_hash_file=False) 
+            self.active_session = None
+            self.current_wordlist_path = None # Clear current wordlist
+            self._try_next_wordlist() # Attempt with the next wordlist
+
+        return None # No password cracked in this update cycle
+
+    def stop_current_crack_attempt(self, cleanup_hash_file=False):
+        if self.active_session:
+            Color.pl(f"{{G}}Real-time: Stopping session for {{C}}{self.current_target_bssid or 'N/A'}{{W}}.")
+            # Determine if the specific hash_file for *this session* should be cleaned.
+            # This is different from the main self.current_hash_file_path which might be persistent.
+            # The session's hash_file_path is what Hashcat was directly using.
+            should_cleanup_session_hash_file = cleanup_hash_file and \
+                                               self.active_session.hash_file_path and \
+                                               self.active_session.hash_file_path.startswith(Configuration.temp())
+            Hashcat.stop_realtime_crack(self.active_session, cleanup_hash_file=should_cleanup_session_hash_file)
+        
+        self.active_session = None
+        # Only clear these if we are truly done with the target or starting a new one.
+        # If called because all wordlists are exhausted, these might be cleared by the caller or next start_target.
+        # For now, let's clear them here to signify the end of attempts for the current_target_bssid.
+        if cleanup_hash_file: # This implies we are done with this BSSID or found password
+             self.current_target_bssid = None
+             self.current_hash_file_path = None
+             self.current_hash_type = None
+             self.current_target_essid = None
+        self.current_wordlist_path = None # Always clear current wordlist path
+        # Do not clear self.wordlist_queue here, it's managed by _load_wordlists and _try_next_wordlist
+
+    def get_cracked_password(self, bssid: str):
+        return self.realtime_cracked_passwords.get(bssid)
+
+    def is_actively_cracking(self, bssid: str = None):
+        if bssid is None:
+            return self.active_session is not None
+        return self.active_session is not None and self.current_target_bssid == bssid
+
+```

--- a/wifite/tools/hashcat.py
+++ b/wifite/tools/hashcat.py
@@ -7,6 +7,24 @@ from ..util.process import Process
 from ..util.color import Color
 
 import os
+import subprocess
+import select
+import signal
+import time # For sleep in stop_realtime_crack
+
+
+class RealtimeHashcatSession:
+    '''Holds information about an active real-time Hashcat cracking session.'''
+    def __init__(self, popen_object, target_bssid, hash_type, hash_file_path,
+                 wordlist_path, outfile_path, potfile_path, user_hashcat_options=None):
+        self.popen_object = popen_object
+        self.target_bssid = target_bssid
+        self.hash_type = hash_type
+        self.hash_file_path = hash_file_path
+        self.wordlist_path = wordlist_path
+        self.outfile_path = outfile_path
+        self.potfile_path = potfile_path
+        self.user_hashcat_options = user_hashcat_options if user_hashcat_options else []
 
 
 class Hashcat(Dependency):
@@ -215,3 +233,203 @@ class HcxPcapTool(Dependency):
 
         os.remove(self.pmkid_file)
         return matching_pmkid_hash
+
+    @staticmethod
+    def start_realtime_crack(target_bssid, hash_file_path, hash_type, wordlist_path, 
+                             user_hashcat_options=None, user_preferences=None):
+        '''
+        Launches Hashcat as a background process for a given hash and wordlist.
+        Returns a RealtimeHashcatSession object or None if Hashcat fails to start.
+        '''
+        if not Configuration.hashcat_path or not os.path.exists(Configuration.hashcat_path):
+            Color.pl('{!} {R}Hashcat path not configured or not found ({O}%s{R}). Cannot start cracking.{W}' % Configuration.hashcat_path)
+            return None
+
+        if not os.path.exists(hash_file_path):
+            Color.pl('{!} {R}Hash file not found: {O}%s{R}. Cannot start cracking.{W}' % hash_file_path)
+            return None
+
+        if not os.path.exists(wordlist_path):
+            Color.pl('{!} {R}Wordlist not found: {O}%s{R}. Cannot start cracking.{W}' % wordlist_path)
+            return None
+
+        temp_dir = Configuration.temp()
+        # Ensure BSSID is filesystem-safe for session name and temp files
+        safe_bssid = target_bssid.replace(":", "").lower()
+        session_name = f'wifite_realtime_{safe_bssid}_{time.strftime("%Y%m%d%H%M%S")}'
+        
+        temp_outfile_path = os.path.join(temp_dir, f'{session_name}.out')
+        temp_potfile_path = os.path.join(temp_dir, f'{session_name}.pot')
+
+        hashcat_cmd = [
+            Configuration.hashcat_path,
+            '-m', str(hash_type),
+            hash_file_path,
+            wordlist_path,
+            '--outfile', temp_outfile_path,
+            '--potfile-path', temp_potfile_path,
+            '--status',
+            '--status-timer', '5', # Update status every 5 seconds
+            '--session', session_name
+        ]
+
+        if user_hashcat_options:
+            hashcat_cmd.extend(user_hashcat_options)
+        
+        if user_preferences:
+            if user_preferences.get('force', False) or Hashcat.should_use_force():
+                hashcat_cmd.append('--force')
+            if 'opencl_device_types' in user_preferences:
+                 hashcat_cmd.extend(['--opencl-device-types', user_preferences['opencl_device_types']])
+            # Add other preferences like --cpu-affinity if needed
+
+        try:
+            # Using os.setpgrp to allow killing the entire process group
+            Color.pl('{+} {C}Starting Hashcat session {O}%s{C} for {O}%s{W}' % (session_name, target_bssid))
+            if Configuration.verbose > 1:
+                 Color.pl('{+} {D}Hashcat command: {W}{P}%s{W}' % ' '.join(hashcat_cmd))
+
+            popen_object = subprocess.Popen(
+                hashcat_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                preexec_fn=os.setpgrp  # Creates a new process group
+            )
+            return RealtimeHashcatSession(
+                popen_object=popen_object,
+                target_bssid=target_bssid,
+                hash_type=hash_type,
+                hash_file_path=hash_file_path, # Store original path, might be needed for cleanup
+                wordlist_path=wordlist_path,
+                outfile_path=temp_outfile_path,
+                potfile_path=temp_potfile_path,
+                user_hashcat_options=user_hashcat_options
+            )
+        except FileNotFoundError:
+            Color.pl('{!} {R}Hashcat executable not found at {O}%s{W}' % Configuration.hashcat_path)
+            return None
+        except Exception as e:
+            Color.pl('{!} {R}Error starting Hashcat: {O}%s{W}' % str(e))
+            return None
+
+    @staticmethod
+    def check_realtime_crack_status(session: RealtimeHashcatSession):
+        '''
+        Reads Hashcat's stdout and checks outfile for results, non-blocking.
+        Returns a dictionary with status, cracked password, and process completion.
+        '''
+        if not session or not session.popen_object:
+            return {'status_lines': [], 'cracked_password': None, 'is_process_complete': True, 'error_lines': ['Session not valid']}
+
+        status_lines = []
+        error_lines = []
+        cracked_password = None
+
+        # Non-blocking read from stdout
+        while session.popen_object.stdout and select.select([session.popen_object.stdout], [], [], 0)[0]:
+            line = session.popen_object.stdout.readline()
+            if line:
+                status_lines.append(line.strip())
+            else: # End of stream
+                break
+        
+        # Non-blocking read from stderr
+        while session.popen_object.stderr and select.select([session.popen_object.stderr], [], [], 0)[0]:
+            line = session.popen_object.stderr.readline()
+            if line:
+                error_lines.append(line.strip())
+            else: # End of stream
+                break
+
+        # Check outfile for cracked password
+        if os.path.exists(session.outfile_path) and os.path.getsize(session.outfile_path) > 0:
+            try:
+                with open(session.outfile_path, 'r') as f:
+                    # Hashcat outfile format: hash[:salt]:plain
+                    # For PMKID (16800) and HCCAPX (2500), it's usually hash:plain or hash:salt:plain
+                    # We are interested in the plain part.
+                    line = f.readline().strip()
+                    if line:
+                        parts = line.split(':')
+                        if len(parts) >= 2: # At least hash:plain
+                             # The last part is the password, but if there are colons in password, join them back
+                            cracked_password = ':'.join(parts[1:]) if session.hash_type != 2500 else ':'.join(parts[2:])
+                            # For HCCAPX (2500), the format is often HCCAPX_HASH:ESSID:MAC_AP:MAC_STA:KEYMIC:EAPOL:PASSWORD
+                            # A simpler split might be needed depending on exact output.
+                            # A common output for -m 2500 is ESSID:hash:salt:password
+                            # Let's assume for now the password is the last field after splitting by colon for simplicity.
+                            # A more robust parsing might be needed depending on specific hashcat output variations.
+                            if session.hash_type == 2500 and len(parts) > 1: # HCCAPX often has ESSID as first part
+                                cracked_password = parts[-1] # Assume password is last part
+                            elif session.hash_type != 2500 and len(parts) > 0 : # For PMKID etc.
+                                cracked_password = parts[-1]
+
+
+            except Exception as e:
+                error_lines.append(f"Error reading outfile: {str(e)}")
+        
+        is_process_complete = session.popen_object.poll() is not None
+
+        return {
+            'status_lines': status_lines,
+            'cracked_password': cracked_password,
+            'is_process_complete': is_process_complete,
+            'error_lines': error_lines
+        }
+
+    @staticmethod
+    def stop_realtime_crack(session: RealtimeHashcatSession, cleanup_hash_file=False):
+        '''Stops the Hashcat process and cleans up temporary files.'''
+        if session and session.popen_object:
+            if session.popen_object.poll() is None: # Process is still running
+                try:
+                    # Send SIGTERM to the entire process group
+                    os.killpg(os.getpgid(session.popen_object.pid), signal.SIGTERM)
+                    Color.pl('{+} {O}Sent SIGTERM to Hashcat session for {C}%s{W}' % session.target_bssid)
+                    session.popen_object.wait(timeout=3) # Wait for graceful termination
+                except ProcessLookupError:
+                    Color.pl('{!} {O}Hashcat process group for {C}%s{O} already gone.{W}' % session.target_bssid)
+                except subprocess.TimeoutExpired:
+                    Color.pl('{!} {O}Hashcat session for {C}%s{O} did not terminate gracefully, sending SIGKILL...{W}' % session.target_bssid)
+                    try:
+                        os.killpg(os.getpgid(session.popen_object.pid), signal.SIGKILL)
+                        session.popen_object.wait(timeout=1) # Wait for kill
+                    except Exception as e:
+                        Color.pl('{!} {R}Error sending SIGKILL to Hashcat: {O}%s{W}' % str(e))
+                except Exception as e: # Catch other errors like process already terminated
+                    Color.pl('{!} {R}Error terminating Hashcat: {O}%s{W}' % str(e))
+            
+            # Close pipes
+            if session.popen_object.stdout:
+                session.popen_object.stdout.close()
+            if session.popen_object.stderr:
+                session.popen_object.stderr.close()
+
+        # Clean up temporary files
+        if session.outfile_path and os.path.exists(session.outfile_path):
+            try:
+                os.remove(session.outfile_path)
+            except Exception as e:
+                Color.pl('{!} {R}Could not remove outfile {O}%s{R}: {O}%s{W}' % (session.outfile_path, str(e)))
+        
+        if session.potfile_path and os.path.exists(session.potfile_path):
+            try:
+                os.remove(session.potfile_path)
+            except Exception as e:
+                Color.pl('{!} {R}Could not remove potfile {O}%s{R}: {O}%s{W}' % (session.potfile_path, str(e)))
+        
+        if cleanup_hash_file and session.hash_file_path and os.path.exists(session.hash_file_path):
+            # Only remove if it's a temporary hash file (e.g. PMKID string written to temp file)
+            # Be cautious not to delete user-provided hash files. This logic might need refinement
+            # based on how hash_file_path is managed (e.g. if it's always copied to temp).
+            # For now, assuming if cleanup_hash_file is True, it's safe.
+            if Configuration.temp() in os.path.abspath(session.hash_file_path):
+                 try:
+                    os.remove(session.hash_file_path)
+                 except Exception as e:
+                    Color.pl('{!} {R}Could not remove temp hash file {O}%s{R}: {O}%s{W}' % (session.hash_file_path, str(e)))
+            else:
+                Color.pl('{!} {O}Skipping cleanup of non-temporary hash file: {C}%s{W}' % session.hash_file_path)
+
+        Color.pl('{+} {C}Hashcat session for {O}%s{C} stopped and cleaned up.{W}' % session.target_bssid)


### PR DESCRIPTION
…canning)

This commit represents the initial research phase for integrating Flipper Zero running Wi-Fi Marauder for parallel scanning capabilities with Wifite.

Research Steps Taken:
1. I identified key GitHub repositories:
   - `0xchocolate/flipperzero-wifi-marauder` (Flipper companion app)
   - `justcallmekoko/ESP32Marauder` (Core ESP32 Marauder firmware & Wiki)
2. I explored the ESP32Marauder Wiki to understand its CLI structure.
3. I confirmed basic serial commands for Wi-Fi AP scanning:
   - `scanap` (to start AP scan)
   - `listap -a` (to list scanned APs - output format pending)
   - `stopscan` (to stop an ongoing scan)
   - `clearlist` (to clear AP/station lists)
   - `channel -s <num>` (to set the Wi-Fi channel) Other commands like `scansta` (for stations) were also noted.

Stuck Point:
The primary blocker for completing the initial research for the *parallel scanning feature* is determining the exact output format of the `listap -a` and `liststa -a` commands from Marauder's CLI. This information is essential for Wifite to parse and utilize the scan results. Further investigation of the Wiki's "Workflow Examples", Flipper-specific pages, or ultimately the source code, is required to find these formats.

Expanded Scope from Your Feedback:
During this research phase, you provided feedback requesting a significantly expanded scope of Flipper Zero/Marauder integration. This includes, but is not limited to:
- Evil Portal functionalities
- Targeted Deauthentication
- Various Beacon Spam attacks
- Multiple advanced sniffing modes (PMKID, specific packet types, BT, etc.)
- Signal Monitoring
- GPS data logging and retrieval
- Saving data to Flipper's SD card
- Bluetooth attacks (various spam types)
- Airtag spoofing
- Comprehensive Wardriving modes

Next Steps (Before Further Implementation):
Due to the expanded scope, a new, more detailed plan will be required to address this comprehensive list of features. The immediate next step for the original scanning feature would have been to find the output formats. However, with the new requirements, a full re-evaluation and new planning cycle is necessary.

This update captures the progress I made on the initial research for parallel scanning.

This pull request introduces significant enhancements to the `README.md` documentation for Wifite and adds comprehensive unit tests for new features related to real-time cracking and PMKID attacks. The changes aim to improve usability, clarify advanced features, and ensure robust testing for recent functionality.

### Documentation Updates

* **Real-Time Hashcat Cracking:** Added detailed instructions for enabling and configuring real-time cracking of PMKIDs and WPA/WPA2 handshakes using Hashcat. New options include specifying wordlists, custom Hashcat options, and controlling CPU/GPU usage.
* **WPA3, OWE, and Wi-Fi 6/7 Support:** Documented new capabilities for identifying WPA3-SAE, OWE networks, and inferred Wi-Fi 6/7 standards. Adjustments to attack strategies for WPA3 targets are highlighted.
* **Dependency Recommendations:** Updated installation guidance to recommend building tools like Aircrack-ng, HCXTools, and Hashcat from source for better support with WPA3 and Wi-Fi 6/7. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R199-R232)

### Unit Tests for Real-Time Cracking and PMKID Attacks

* **Tests for Real-Time Cracking:** Added test cases in `test_AttackAll.py` to validate behavior when real-time cracking succeeds or stops due to other successful attacks. Mocking ensures no actual attacks are performed.
* **Tests for PMKID Attack:** Added test cases in `test_AttackPMKID.py` to verify PMKID hash capture and integration with the real-time cracking manager. Includes mocking of tools like `HcxDumpTool` and `HcxPcapTool`.

These changes enhance both the usability of Wifite and its reliability through robust testing.